### PR TITLE
Bugfix/fix issue with url references not updating

### DIFF
--- a/clients/confluence_client.py
+++ b/clients/confluence_client.py
@@ -124,6 +124,8 @@ class ConfluenceClient:
     def update_page(self, page_id, title, content, version, version_message):
         url = f"{self.base_url_v2}/pages/{page_id}"
 
+        self.logger.debug(f"Updating page in confluence {title} - {page_id} - {version}")
+
         payload = {
             "id": page_id,
             "status": "current",

--- a/s2c_migator.py
+++ b/s2c_migator.py
@@ -442,8 +442,8 @@ class SliteToConfluenceMigrator:
                     continue
 
                 for i, (pages_dict, old_title, data, parent_title) in enumerate(entries):
-                    new_title = f"{old_title} ({parent_title})"
-                    self.logger.debug(f"Updating {old_title} to {new_title}.")
+                    new_title = f"{old_title.strip()} ({parent_title})"
+                    self.logger.debug(f"Updating {old_title.strip()} to {new_title}.")
                     if new_title in used_titles:
                         self.logger.debug(f"{new_title} is still not unique!")
                         new_title = f"{new_title} {shortuuid.ShortUUID().random(8)}"

--- a/s2c_migator.py
+++ b/s2c_migator.py
@@ -372,8 +372,6 @@ class SliteToConfluenceMigrator:
 
             if page_data.get("parent"):
                 self.logger.debug(f"    Page {title} has parent {page_data['parent']}")
-                self.url_map[page_data["path"]] = f'{self.client.base_space_url}/{space_key}/pages/{page_data["page_id"]}'
-                self._save_progress("url_map")
 
             if page_data.get("uploaded"):
                 self.logger.debug(f"        Page {title} is already uploaded. Progressing.")


### PR DESCRIPTION
Resolved issue with url references not updating, one issue with a regex causing catastrophic backtracking when replacing urls. The other issue with the url_map being overwritten.

There is still an outstanding issue where urls (either internal or external) reference the same document in confluence, and not the target url as it is in Slite.